### PR TITLE
SELinux Configuration Recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,3 +21,6 @@ suites:
     attributes:
         environment_vars:
             testing: true
+        selinux:
+            dev_packages:
+              enabled: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,10 +37,10 @@ when 'rhel'
     default['epel']['package_name'] = 'epel-release'
     default['epel']['repo_name']    = 'epel'
 
-    default['selinux']['mode']                      = 'permissive'
-    default['selinux']['type']                      = 'targeted'
-    default['selinux']['dev_packages']['enabled']   = false
-    default['selinux']['dev_packages']['packages']  = %w(
+    default['selinux']['mode']                     = 'permissive'
+    default['selinux']['type']                     = 'targeted'
+    default['selinux']['dev_packages']['enabled']  = false
+    default['selinux']['dev_packages']['packages'] = %w(
         policycoreutils-python
         setools-console
         setroubleshoot

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,4 +36,12 @@ when 'rhel'
 
     default['epel']['package_name'] = 'epel-release'
     default['epel']['repo_name']    = 'epel'
+
+    default['selinux']['dev_packages']['enabled'] = false
+    default['selinux']['dev_packages']['packages'] = %w(
+        policycoreutils-python
+        setools-console
+        setroubleshoot
+        setroubleshoot-server
+    )
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,8 +37,10 @@ when 'rhel'
     default['epel']['package_name'] = 'epel-release'
     default['epel']['repo_name']    = 'epel'
 
-    default['selinux']['dev_packages']['enabled'] = false
-    default['selinux']['dev_packages']['packages'] = %w(
+    default['selinux']['mode']                      = 'permissive'
+    default['selinux']['type']                      = 'targeted'
+    default['selinux']['dev_packages']['enabled']   = false
+    default['selinux']['dev_packages']['packages']  = %w(
         policycoreutils-python
         setools-console
         setroubleshoot

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email    'engineering@copiousinc.com'
 license             'MIT'
 description         'Base OS packages.'
 long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version             '0.0.11'
+version             '0.0.12'
 source_url          'https://github.com/copious-cookbooks/base'
 issues_url          'https://github.com/copious-cookbooks/base/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,3 +7,7 @@ include_recipe 'cop_base::dependencies'
 include_recipe 'cop_ntp::default'
 include_recipe 'cop_base::packages'
 include_recipe 'cop_base::variables'
+
+if node['platform_family'] == 'rhel'
+    include_recipe 'cop_base::selinux'
+end

--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -3,8 +3,8 @@
 # Recipe:: selinux
 #
 
-selinux         = node['selinux']
-dev_packages    = selinux['dev_packages']
+selinux      = node['selinux']
+dev_packages = selinux['dev_packages']
 
 if dev_packages['enabled']
     dev_pacakages['packages'].each do |p|

--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -3,11 +3,11 @@
 # Recipe:: selinux
 #
 
-selinux         = node[:selinux]
-dev_packages    = selinux[:dev_packages]
+selinux         = node['selinux']
+dev_packages    = selinux['dev_packages']
 
-if dev_packages[:enabled]
-    dev_pacakages[:packages].each do |p|
+if dev_packages['enabled']
+    dev_pacakages['packages'].each do |p|
         package p do
             action :install
         end
@@ -16,11 +16,11 @@ end
 
 # Set SELinux config on boot
 file '/etc/selinux/config' do
-    content "SELINUX=permissive\nSELINUXTYPE=targeted"
+    content "SELINUX=#{selinux['mode']}\nSELINUXTYPE=#{selinux['type']}"
 end
 
 # Set SELinux mode in session
-execute 'Setting SELinux mode to permissive' do
+execute "Setting SELinux mode to #{selinux['mode']}" do
     command 'setenforce 0'
-    not_if  'sestatus | grep "^Current mode.*permissive$"'
+    not_if  "sestatus | grep '^Current mode.*#{selinux['mode']}$'"
 end

--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -7,7 +7,7 @@ selinux      = node['selinux']
 dev_packages = selinux['dev_packages']
 
 if dev_packages['enabled']
-    dev_pacakages['packages'].each do |p|
+    dev_packages['packages'].each do |p|
         package p do
             action :install
         end

--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: base
+# Recipe:: selinux
+#
+
+selinux         = node[:selinux]
+dev_packages    = selinux[:dev_packages]
+
+if dev_packages[:enabled]
+    dev_pacakages[:packages].each do |p|
+        package p do
+            action :install
+        end
+    end
+end
+
+# Set SELinux config on boot
+file '/etc/selinux/config' do
+    content "SELINUX=permissive\nSELINUXTYPE=targeted"
+end
+
+# Set SELinux mode in session
+execute 'Setting SELinux mode to permissive' do
+    command 'setenforce 0'
+    not_if  'sestatus | grep "^Current mode.*permissive$"'
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -20,3 +20,37 @@ describe 'base::default' do
     it { should contain 'testing=true' }
   end
 end
+
+describe 'base::selinux' do
+    case os[:family]
+    when 'ubuntu', 'debian'
+         describe file('/etc/selinux/config') do
+             it { should_not exist }
+         end
+
+         describe package('setools-console') do
+             it { should_not be_installed }
+         end
+
+         describe command('sestatus') do
+             its(:exit_status) { should_not eq 0 }
+         end
+    when 'redhat'
+        describe file('/etc/selinux/config') do
+            it { should contain "SELINUX=permissive" }
+        end
+
+        describe file('/etc/selinux/config') do
+            it { should contain "SELINUXTYPE=targeted" }
+        end
+
+         describe package('setools-console') do
+             it { should be_installed }
+         end
+
+        describe command('sestatus') do
+            its(:exit_status) { should eq 0 }
+            its(:stdout) { should contain "^Current mode.*permissive$" }
+        end
+    end
+end


### PR DESCRIPTION
This recipe configures SELinux on RHEL based systems.

The following default attributes are added:
* SELinux mode: permissive
* SELinux type: targeted
* dev_packages enabled: false
* dev_packages packages: array of development packages to install

The following items are added to the new SELinux recipe:
* Installs development packages if specified
* Modify `/etc/sysconfg/selinux` with specified attributes
* Update SELinux mode in current session

In addition, a set of Kitchen tests is included for this recipe.