### PR TITLE
Update test kitchen boxes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,13 +6,13 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-12.04
-  - name: ubuntu-14.04
-  - name: ubuntu-16.04
-  - name: centos-6.8
-  - name: centos-7.2
-  - name: debian-7.11
-  - name: debian-8.6
+  - name: ubuntu/precise64
+  - name: ubuntu/trusty64
+  - name: ubuntu/xenial64
+  - name: centos/6
+  - name: centos/7
+  - name: debian/wheezy64
+  - name: debian/jessie64
 
 suites:
   - name: default


### PR DESCRIPTION
This pull request replaces the Vagrant box definitions in `.kitchen.yml` to use the native provider defaults instead of Bento built boxes. All tests pass, otherwise this wouldn't be a very good pull request.