### PR TITLE
Pin Chef to last stable v12 release

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,8 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12.19.36
+  # NOTE: 13.0.113 breaks 'packages' recipe, see https://github.com/copious-cookbooks/base/issues/15
 
 platforms:
   - name: ubuntu/precise64


### PR DESCRIPTION
Temporarily addresses https://github.com/copious-cookbooks/base/issues/15 by pinning chef to the last stable Chef v12 release.