### PR TITLE
Update 'packages' recipe, validate Chef v13

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,6 @@ provisioner:
   # NOTE: 13.0.113 breaks 'packages' recipe, see https://github.com/copious-cookbooks/base/issues/15
 
 platforms:
-  - name: ubuntu/precise64
   - name: ubuntu/trusty64
   - name: ubuntu/xenial64
   - name: centos/6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,8 +4,8 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.19.36
-  # NOTE: 13.0.113 breaks 'packages' recipe, see https://github.com/copious-cookbooks/base/issues/15
+  require_chef_omnibus: 13.1.31
+  # NOTE: 13.1.31 Last tested version
 
 platforms:
   - name: ubuntu/trusty64

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Base OS packages
 
 ## Requirements
 ### Platforms
-- Ubuntu '>= 12.04'
+- Ubuntu '>= 14.04'
 - Debian '>= 7.0'
 - Rhel '>= 6.0'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ issues_url          'https://github.com/copious-cookbooks/base/issues'
 depends 'apt'
 depends 'cop_ntp'
 
-supports 'ubuntu', '>= 12.04'
+supports 'ubuntu', '>= 14.04'
 supports 'debian', '>= 7'
 supports 'rhel'
 supports 'centos', '>= 6'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email    'engineering@copiousinc.com'
 license             'MIT'
 description         'Base OS packages.'
 long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version             '0.0.12'
+version             '0.1.0'
 source_url          'https://github.com/copious-cookbooks/base'
 issues_url          'https://github.com/copious-cookbooks/base/issues'
 

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -1,3 +1,8 @@
+#
+# Cookbook Name:: base
+# Recipe:: dependencies
+#
+
 case node['platform_family']
 when 'debian'
     include_recipe 'apt::default'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,8 +1,13 @@
-unless node['packages']['install'].nil? || node['packages']['install'].empty?
-    node['packages']['install'].each do |pkg|
-       package pkg do
-            action  :install
-            options "--enablerepo=#{node['epel']['repo_name']}" if node['platform_family'] == 'rhel'
-        end
+#
+# Cookbook Name:: base
+# Recipe:: packages
+#
+
+packages = node['packages']['install']
+
+unless packages.nil? || packages.empty?
+    package packages do
+        action  :install
+        options "--enablerepo=#{node['epel']['repo_name']}" if node['platform_family'] == 'rhel'
     end
 end

--- a/recipes/variables.rb
+++ b/recipes/variables.rb
@@ -1,3 +1,8 @@
+#
+# Cookbook Name:: base
+# Recipe:: variables
+#
+
 file '/etc/environment' do
     owner  'root'
     group  'root'


### PR DESCRIPTION
Refactors 'packages' recipes to follow Chef prescribed best practices, in addition to speeding up package installation.

Drops support for Ubuntu Precise 12.04 and removes from Kitchen test list.

Adds descriptive headers to all recipes that were previously lacking.